### PR TITLE
Update beat tracking after in-stream loop jump

### DIFF
--- a/audio_engine/deck.py
+++ b/audio_engine/deck.py
@@ -1371,7 +1371,12 @@ class Deck:
                 old_frame = self.audio_thread_current_frame
                 self.audio_thread_current_frame = valid_target_frame
                 self._current_playback_frame_for_display = valid_target_frame
-                
+
+                # Keep beat tracking aligned with the new position
+                self.beat_manager.update_from_frame(
+                    self.audio_thread_current_frame, self.audio_thread_sample_rate
+                )
+
                 # 4. Clear any pending audio data to prevent artifacts
                 if hasattr(self, '_pending_out') and self._pending_out is not None:
                     self._pending_out = None


### PR DESCRIPTION
## Summary
- Keep BeatManager in sync during seamless loop jumps by updating from new frame position

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6e25910e4832289389ad6198c5615