### PR TITLE
Ensure ring buffer filled during seamless loop jumps

### DIFF
--- a/audio_engine/deck.py
+++ b/audio_engine/deck.py
@@ -1384,10 +1384,20 @@ class Deck:
                 # Prime ring buffer with fresh audio after position jump
                 if hasattr(self, '_producer_startup_mode'):
                     self._producer_startup_mode = True
-                prefill = self._produce_chunk_rubberband(self.sample_rate // 16)
-                if self.out_ring and prefill is not None:
+                prefilled = 0
+                TARGET_BLOCK = 4096
+                while self.out_ring and prefilled < self.RING_BUFFER_SIZE:
+                    frames_needed = self.RING_BUFFER_SIZE - prefilled
+                    chunk_size = min(TARGET_BLOCK, frames_needed)
+                    prefill = self._produce_chunk_rubberband(chunk_size)
+                    if prefill is None:
+                        break
                     self.out_ring.write(prefill)
-                
+                    prefilled += len(prefill)
+
+                if self.out_ring:
+                    self._wait_for_ring_buffer_ready()
+
                 logger.info(f"Deck {self.deck_id} - Seamless jump: {old_frame} → {valid_target_frame} (no restart)")
                 return True
                 


### PR DESCRIPTION
## Summary
- Replace single chunk prefill in `_perform_seamless_loop_jump_in_stream` with a loop that fills the ring buffer in `TARGET_BLOCK` chunks
- After priming, wait for ring buffer readiness to avoid underruns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6e5f69f108322a4ef1992721f137d