### PR TITLE
Add loop playback and scheduling to DJ engine

### DIFF
--- a/architecture/loop_mgmt_implementation_plan.md
+++ b/architecture/loop_mgmt_implementation_plan.md
@@ -1,0 +1,37 @@
+# Loop Management Implementation Plan
+
+## Phase 1: Core Loop Playback
+- Add loop state to `Deck` (start/end frames, iteration counters).
+- Implement `activate_loop`/`deactivate_loop` methods.
+- Build loop-aware audio chunk generation that seamlessly wraps frames and logs iteration/jump/completion events.
+- Ensure playback works with existing EQ and stem mixing.
+
+## Phase 2: Engine Integration
+- Extend `AudioEngine` validation and scheduling to support `activate_loop` and `on_loop_complete` triggers.
+- Maintain mapping from loop IDs to completion actions.
+- Provide `handle_loop_complete` for decks to notify engine.
+
+## Phase 3: Loop Chaining & Multiple Actions
+- Support sequential loop activation via `on_loop_complete` triggers.
+- Allow multiple actions to fire when a loop completes.
+- Verify cross-deck targeting and event ordering.
+
+## Phase 4: Configuration & Validation
+- Validate JSON parameters (start beat, length, repetitions).
+- Ensure beat/frame conversions handle fractional beats accurately.
+- Add bounds checking against track length.
+
+## Phase 5: Observability & Debugging
+- Implement INFO-level logging for loop lifecycle events and jumps.
+- Expose loop state via engine for monitoring.
+- Record timing metrics for loop accuracy.
+
+## Phase 6: Performance & Safety
+- Optimize loop processing in the producer thread to avoid audio dropouts.
+- Ensure thread-safe access to loop state.
+- Add tests for tight loops and edge cases.
+
+Each phase can be developed and merged independently, enabling incremental delivery of the full loop management system.
+
+## Status
+- Phase 1 and Phase 2 implemented in current iteration.

--- a/audio_engine/adapters/deck_executor_adapter.py
+++ b/audio_engine/adapters/deck_executor_adapter.py
@@ -29,15 +29,17 @@ class DeckExecutorAdapter(ActionExecutor):
         
         # Engine-level commands that should be routed to the engine
         self._engine_commands = {'crossfade', 'bpm_match'}
-        
+
         # Map action types to deck methods
         self._action_methods = {
             'play': self._execute_play,
-            'pause': self._execute_pause, 
+            'pause': self._execute_pause,
             'stop': self._execute_stop,
             'seek': self._execute_seek,
             'set_volume': self._execute_set_volume,
-            'set_tempo': self._execute_set_tempo
+            'set_tempo': self._execute_set_tempo,
+            'activate_loop': self._execute_activate_loop,
+            'deactivate_loop': self._execute_deactivate_loop
         }
         
         # Validate deck has basic required methods
@@ -247,6 +249,33 @@ class DeckExecutorAdapter(ActionExecutor):
                 
         except Exception as e:
             logger.error(f"Deck {self._deck_id}: Error setting tempo: {e}")
+            return False
+
+    def _execute_activate_loop(self, params: Dict[str, Any], context: Dict[str, Any]) -> bool:
+        """Execute activate_loop action"""
+        try:
+            start_at_beat = params.get('start_at_beat') or params.get('start_beat')
+            length_beats = params.get('length_beats')
+            repetitions = params.get('repetitions')
+
+            if start_at_beat is None or length_beats is None:
+                logger.error(f"Deck {self._deck_id}: Missing loop parameters")
+                return False
+
+            action_id = context.get('action_id')
+            return bool(self._deck.activate_loop(start_at_beat, length_beats, repetitions, action_id))
+
+        except Exception as e:
+            logger.error(f"Deck {self._deck_id}: Error activating loop: {e}")
+            return False
+
+    def _execute_deactivate_loop(self, params: Dict[str, Any], context: Dict[str, Any]) -> bool:
+        """Execute deactivate_loop action"""
+        try:
+            self._deck.deactivate_loop()
+            return True
+        except Exception as e:
+            logger.error(f"Deck {self._deck_id}: Error deactivating loop: {e}")
             return False
     
     


### PR DESCRIPTION
## Summary
- Add per-deck loop state with `activate_loop`/`deactivate_loop` APIs and seamless looped mixing
- Track loop iterations and completion, dispatching follow-up actions via the engine
- Document phased plan for loop management rollout
- Register loop actions with the deck executor so scheduled JSON commands trigger loops correctly

## Testing
- `python -m py_compile audio_engine/adapters/deck_executor_adapter.py audio_engine/deck.py audio_engine/engine.py`
- `python main.py mix_configs/starships_simple.json --max_wait_after_script 10 --log-level INFO` *(fails: No module named 'essentia')*


------
https://chatgpt.com/codex/tasks/task_e_68b7ab326f5c832297970a2862afa061