### PR TITLE
Handle loop completion actions when scheduler idle

### DIFF
--- a/audio_engine/engine.py
+++ b/audio_engine/engine.py
@@ -176,15 +176,33 @@ class AudioEngine:
         # Could implement error recovery logic here
 
     def handle_loop_complete(self, deck_id: str, loop_action_id: str):
-        """Execute actions registered for a completed loop"""
+        """Dispatch actions registered for a completed loop"""
         actions = self._loop_completion_actions.get(deck_id, {}).pop(loop_action_id, [])
         if deck_id in self._loop_completion_actions and not self._loop_completion_actions[deck_id]:
             del self._loop_completion_actions[deck_id]
         for action in actions:
             try:
-                self._execute_action(action)
+                # Prefer scheduling via EventScheduler so actions run on the main
+                # dispatch thread. However, the scheduler may exist but not be
+                # running (e.g. when operating in frame-accurate mode). In that
+                # case the queued action would never execute, so fall back to
+                # direct execution.
+                if self.event_scheduler and self.event_scheduler.is_running():
+                    self.event_scheduler.schedule_immediate_action(action)
+                    logger.info(
+                        "handle_loop_complete: scheduled action %s via EventScheduler",
+                        action.get("action_id"),
+                    )
+                else:
+                    logger.info(
+                        "handle_loop_complete: executing action %s directly (scheduler inactive)",
+                        action.get("action_id"),
+                    )
+                    self._execute_action(action)
             except Exception as e:
-                logger.error(f"Error executing loop completion action {action.get('action_id')}: {e}")
+                logger.error(
+                    f"Error executing loop completion action {action.get('action_id')}: {e}"
+                )
 
     def _validate_action(self, action, action_index):
         command = action.get("command")


### PR DESCRIPTION
## Summary
- execute loop-complete actions immediately when the event scheduler isn't running
- add debug logs showing whether actions were scheduled or executed directly
- elevate loop-complete action path logs to info level for easier diagnostics
- register loop-complete actions in the frame-accurate mix loader so STOP triggers fire after loops finish

## Testing
- `python -m py_compile audio_engine/engine.py audio_engine/deck.py audio_engine/mix_loader.py`
- Attempted to load `mix_configs/starships_simple.json` but missing dependency `essentia`; `pip install` failed to find a matching distribution

------
https://chatgpt.com/codex/tasks/task_e_68b8440c8d188322b87d1ff2883827f3