### PR TITLE
fix stop command flush behavior to allow final loop playback

### DIFF
--- a/audio_engine/deck.py
+++ b/audio_engine/deck.py
@@ -1991,17 +1991,19 @@ class Deck:
                     if data is not None and isinstance(data, dict):
                         flush = data.get("flush", True)
 
-                    # Stop producer thread
+                    # Stop producer thread so no new audio is generated
                     self._producer_stop_event.set()
                     self._producer_running = False
 
-                    # Clear any buffered audio so playback stops immediately
-                    self._clear_ring_buffer_for_position_jump("stop command")
-
-
-                    # Clear any buffered audio so playback stops immediately
+                    # Only clear the ring buffer if caller explicitly requested
+                    # an immediate stop. Otherwise allow existing audio to drain
+                    # naturally so loop completions can play out fully.
                     if flush:
                         self._clear_ring_buffer_for_position_jump("stop command")
+                    else:
+                        logger.debug(
+                            f"Deck {self.deck_id} AudioThread - STOP without flush: allowing buffer to drain"
+                        )
 
                     # Clean up RubberBand resources
                     self._cleanup_rubberband_on_stop()

--- a/audio_engine/engine.py
+++ b/audio_engine/engine.py
@@ -1134,7 +1134,10 @@ class AudioEngine:
             elif command == "stop":
                 if not deck_id: logger.warning("'stop' missing deck_id. Skipping."); return False
                 deck = self._get_or_create_deck(deck_id)
-                flush = parameters.get("flush", True)
+                # Default to non-flushing stop so any buffered audio (e.g. final
+                # loop iteration) can play out unless the caller explicitly
+                # requests an immediate stop.
+                flush = parameters.get("flush", False)
                 deck.stop(flush=flush)
                 return False  # Engine convention: False = success
             


### PR DESCRIPTION
## Summary
- honor stop command flush flag to allow buffered audio to drain
- default to non-flushing stop so loop completions aren't truncated

## Testing
- `python -m py_compile audio_engine/deck.py audio_engine/engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68b868404064832292edda280436f3f1